### PR TITLE
fix Article struct

### DIFF
--- a/src/cpp.rs
+++ b/src/cpp.rs
@@ -222,7 +222,9 @@ pub mod root {
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
         pub struct Article {
-            pub battle_object : BattleObject,
+            pub vtable: *const *const skyline::libc::c_void,
+            pub module_accessor: *mut root::app::BattleObjectModuleAccessor,
+            pub generate_id: i32,
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Current version returns misaligned data if you attempt to use it directly (e.g. `(*article).battle_object.battle_object_id` produces half of a pointer, not the actual ID). This fixes it so you can get the module_accessor properly (`(*article).module_accessor`) and then work from there.